### PR TITLE
fixes-typo

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,6 +1,6 @@
 export { default as Home } from "./home";
 export { default as Explore } from "./explore";
-export { default as Messages } from "./Messages";
+export { default as Messages } from "./messages";
 export { default as Notifications } from "./notifications";
 export { default as Profile } from "./profile";
 export { default as Search } from "./search";


### PR DESCRIPTION
This change resolves the typo in the pages/index.js file that was preventing the website from loading.